### PR TITLE
[#26] 경유 정류장 JPA 연동 및 기본 서비스 구현

### DIFF
--- a/bus-seat/src/main/java/org/kernel360/busseat/route_station/controller/BusRouteStationController.java
+++ b/bus-seat/src/main/java/org/kernel360/busseat/route_station/controller/BusRouteStationController.java
@@ -1,0 +1,39 @@
+package org.kernel360.busseat.route_station.controller;
+
+import java.util.List;
+
+import org.kernel360.busseat.route_station.dto.RouteStationDto;
+import org.kernel360.busseat.route_station.service.BusRouteStationService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/route-stations")
+@RequiredArgsConstructor
+public class BusRouteStationController {
+	private final BusRouteStationService busRouteStationService;
+
+	@GetMapping("/{routeStationId}")
+	public RouteStationDto findById(@PathVariable("routeStationId") Long routeStationId) {
+		return busRouteStationService.findById(routeStationId).orElse(null);
+	}
+
+	@GetMapping("/")
+	public List<RouteStationDto> findAll() {
+		return busRouteStationService.findAll();
+	}
+
+	@GetMapping("/route/{routeId}")
+	public List<RouteStationDto> findByRouteId(@PathVariable("routeId") Long routeId) {
+		return busRouteStationService.findByRouteId(routeId);
+	}
+
+	@GetMapping("/route/{routeId}/seq/{seq}")
+	public RouteStationDto findByRouteIdAndSeq(@PathVariable("routeId") Long routeId, @PathVariable("seq") Short seq) {
+		return busRouteStationService.findByRouteIdAndSeq(routeId, seq).orElse(null);
+	}
+}

--- a/bus-seat/src/main/java/org/kernel360/busseat/route_station/dto/RouteStationDto.java
+++ b/bus-seat/src/main/java/org/kernel360/busseat/route_station/dto/RouteStationDto.java
@@ -1,0 +1,28 @@
+package org.kernel360.busseat.route_station.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RouteStationDto {
+	private Long busRouteStopId;
+
+	private Long routeId;
+
+	private Long stationId;
+
+	private Short stationSeq;
+
+	private String stationName;
+
+	private String regionName;
+
+	private String districtCd;
+}

--- a/bus-seat/src/main/java/org/kernel360/busseat/route_station/entity/BusRouteStationEntity.java
+++ b/bus-seat/src/main/java/org/kernel360/busseat/route_station/entity/BusRouteStationEntity.java
@@ -1,0 +1,36 @@
+package org.kernel360.busseat.route_station.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity(name = "bus_route_station")
+public class BusRouteStationEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long busRouteStopId;
+
+	private Long routeId;
+
+	private Long stationId;
+
+	private Short stationSeq;
+
+	private String stationName;
+
+	private String regionName;
+
+	private String districtCd;
+
+	private Timestamp createdAt;
+}

--- a/bus-seat/src/main/java/org/kernel360/busseat/route_station/repository/BusRouteStationRepository.java
+++ b/bus-seat/src/main/java/org/kernel360/busseat/route_station/repository/BusRouteStationRepository.java
@@ -1,0 +1,13 @@
+package org.kernel360.busseat.route_station.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.kernel360.busseat.route_station.entity.BusRouteStationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusRouteStationRepository extends JpaRepository<BusRouteStationEntity, Long> {
+	public List<BusRouteStationEntity> findByRouteId(Long routeId);
+
+	public Optional<BusRouteStationEntity> findByRouteIdAndStationSeq(Long routeId, Short seq);
+}

--- a/bus-seat/src/main/java/org/kernel360/busseat/route_station/service/BusRouteStationService.java
+++ b/bus-seat/src/main/java/org/kernel360/busseat/route_station/service/BusRouteStationService.java
@@ -1,0 +1,47 @@
+package org.kernel360.busseat.route_station.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.kernel360.busseat.route_station.dto.RouteStationDto;
+import org.kernel360.busseat.route_station.entity.BusRouteStationEntity;
+import org.kernel360.busseat.route_station.repository.BusRouteStationRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BusRouteStationService {
+	private final BusRouteStationRepository busRouteStationRepository;
+
+	public Optional<RouteStationDto> findById(Long id) {
+		return this.busRouteStationRepository.findById(id).map(this::toDto);
+	}
+
+	public List<RouteStationDto> findAll() {
+		return this.busRouteStationRepository.findAll()
+			.stream().map(this::toDto).toList();
+	}
+
+	public List<RouteStationDto> findByRouteId(Long routeId) {
+		return this.busRouteStationRepository.findByRouteId(routeId)
+			.stream().map(this::toDto).toList();
+	}
+
+	public Optional<RouteStationDto> findByRouteIdAndSeq(Long routeId, Short seq) {
+		return this.busRouteStationRepository.findByRouteIdAndStationSeq(routeId, seq).map(this::toDto);
+	}
+
+	private RouteStationDto toDto(BusRouteStationEntity entity) {
+		return RouteStationDto.builder()
+			.busRouteStopId(entity.getBusRouteStopId())
+			.routeId(entity.getRouteId())
+			.stationId(entity.getStationId())
+			.stationSeq(entity.getStationSeq())
+			.stationName(entity.getStationName())
+			.regionName(entity.getRegionName())
+			.districtCd(entity.getDistrictCd())
+			.build();
+	}
+}

--- a/data/mysql-files/schema.sql
+++ b/data/mysql-files/schema.sql
@@ -1,14 +1,14 @@
 DROP TABLE IF EXISTS `BUS_STATION`;
 CREATE TABLE `BUS_STATION`
 (
-    `station_id`       BIGINT(32)       NOT NULL PRIMARY KEY COMMENT '교통 API 상 식별자 (UNIQUE)',
-    `station_name`     VARCHAR(100)     NOT NULL COMMENT '정류장 이름',
-    `station_type`     VARCHAR(10)  NOT NULL COMMENT '정류장 유형',
-    `station_name_en`  VARCHAR(200) NOT NULL COMMENT '정류장 영문 이름',
-    `registered_at`    TIMESTAMP    NOT NULL COMMENT '교통 API 상 등록일자',
-    `latitude`         DECIMAL(17,14)    NOT NULL COMMENT '정류장 위도',
-    `longitude`        DECIMAL(17,14) NOT NULL COMMENT '정류장 경도',
-    `created_at`       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '데이터 생성일자'
+    `station_id`      BIGINT(32)      NOT NULL PRIMARY KEY COMMENT '교통 API 상 식별자 (UNIQUE)',
+    `station_name`    VARCHAR(100)    NOT NULL COMMENT '정류장 이름',
+    `station_type`    VARCHAR(10)     NOT NULL COMMENT '정류장 유형',
+    `station_name_en` VARCHAR(200)    NOT NULL COMMENT '정류장 영문 이름',
+    `registered_at`   TIMESTAMP       NOT NULL COMMENT '교통 API 상 등록일자',
+    `latitude`        DECIMAL(17, 14) NOT NULL COMMENT '정류장 위도',
+    `longitude`       DECIMAL(17, 14) NOT NULL COMMENT '정류장 경도',
+    `created_at`      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '데이터 생성일자'
 );
 
 DROP TABLE IF EXISTS `BUS_ROUTE`;
@@ -39,7 +39,7 @@ CREATE TABLE `BUS_ROUTE_LOCATION`
 DROP TABLE IF EXISTS `BUS_ROUTE_STATION`;
 CREATE TABLE `BUS_ROUTE_STATION`
 (
-    `BUS_ROUTE_stop_id` BIGINT(32)   NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT '단순 식별자',
+    `bus_route_stop_id` BIGINT(32)   NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT '단순 식별자',
     `route_id`          BIGINT(32)   NOT NULL,
     `station_id`        BIGINT(32)   NOT NULL,
     `station_seq`       SMALLINT     NOT NULL,


### PR DESCRIPTION
## 구현 내용 
- ERD 상에 존재하던 경유 정류장 JPA 연동
- 기본 READ 관련 서비스 / 컨트롤러 구현